### PR TITLE
Generation of robots.txt will now respect the relativedest option.

### DIFF
--- a/sitemap.js
+++ b/sitemap.js
@@ -46,6 +46,11 @@ module.exports  = function (params, callback) {
     return grunt.verbose.ok(msg);
   };
 
+  // Return the relative destination if the option is enabled
+  var getRelativeDest = function(relativedest, file) {
+    return (relativedest ? file.dest.replace(file.filePair.orig.dest + "/", "") : file.dest );
+  };
+
   async.forEach(pages, function (file, next) {
 
     if(!_.isUndefined(options.exclude)) {
@@ -59,13 +64,13 @@ module.exports  = function (params, callback) {
     var relativedest = options.relativedest;
     
     if(exclusion.indexOf(file.basename) !== -1) {
-      robots.push('Disallow: /' + file.dest);
+      robots.push('Disallow: /' + getRelativeDest(relativedest, file));
       return;
     }
 
     sitemap.push({
       url: {
-        loc: url + '/' + (relativedest ? file.dest.replace(file.filePair.orig.dest+"/","") : file.dest ),
+        loc: url + '/' + getRelativeDest(relativedest, file),
         lastmod: date.toISOString(),
         changefreq: changefreq,
         priority: priority

--- a/test/actual/sitemap_relative/robots.txt
+++ b/test/actual/sitemap_relative/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 
-Disallow: /test/actual/sitemap_relative/404.html
-Disallow: /test/actual/sitemap_relative/foo.html
+Disallow: /404.html
+Disallow: /foo.html


### PR DESCRIPTION
When using the relativedest option I believe the robots.txt should also respect this. It is common to output everything to a "dest" or "dist" folder that ends up being the root of your website. This change allows the robots.txt file to match what is done in the sitemap.xml and how the rest of assemble works.
