### PR TITLE
Adding an option to remove index.html from the sitemap, add a custom output filename, and some documentation fixes.

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -41,7 +41,7 @@ Pages to omit from the sitemap.
 ```js
 options: {
   sitemap: {
-    exclusions: ["foo", "bar"],
+    exclude: ["foo", "bar"],
   },
   files: {
     ...
@@ -60,3 +60,9 @@ Type: `Boolean`
 Default: `true`
 
 Generate robots.txt from `exclusions` list.
+
+## flattendirectoryindex
+Type: `Boolean`
+Default: `false`
+
+When generating a sitemap with directory indexes, flatten `http://www.example.com/directory/index.html` to `http://www.example.com/directory/`

--- a/docs/options.md
+++ b/docs/options.md
@@ -32,7 +32,7 @@ Default: `0.5`
 
 The priority of this URL relative to other URLs on your site. Valid values range from 0.0 to 1.0. This value does not affect how your pages are compared to pages on other sites—it only lets the search engines know which pages you deem most important for the crawlers.
 
-## exclusions
+## exclude
 Type: `Array`  
 Default: `['404']`
 
@@ -54,6 +54,12 @@ Type: `String` / `Boolean`
 Default: `false`
 
 Path to which the URLs in Sitemap and Robots should be relative to. `true` is equal to the destination path `dest` and `false` is equal to the root directory.
+
+## outputfilename
+Type: `String`
+Default: `sitemap.xml`
+
+If you have a master sitemap that references sub-sitemaps, use this feature. For example `static-sitemap.xml`
 
 ## robot
 Type: `Boolean`  

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports  = function (params, callback) {
   options.changefreq = options.changefreq || 'weekly';
   options.priority = (options.priority || 0.5).toString();
   options.dest = options.dest || path.dirname(pages[0].dest);
+  options.flattendirectoryindex = options.flattendirectoryindex || false;
 
 
   // Only write if it actually changed.
@@ -45,8 +46,13 @@ module.exports  = function (params, callback) {
 
   // Return the relative destination if the option is enabled
   var getExternalFilePath = function (relativedest, file) {
+    var finalFilename = file.dest;
+
     if(relativedest === true) {
       relativedest = options.dest;
+    }
+    if (options.flattendirectoryindex === true) {
+      finalFilename = file.dest.replace("index.html", "");
     }
     return (relativedest ? file.dest.replace(relativedest + "/", "") : file.dest );
   };

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports  = function (params, callback) {
     if (options.flattendirectoryindex === true) {
       finalFilename = file.dest.replace("index.html", "");
     }
-    return (relativedest ? file.dest.replace(relativedest + "/", "") : file.dest );
+    return (relativedest ? finalFilename.replace(relativedest + "/", "") : finalFilename );
   };
 
   var url = options.homepage;

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports  = function (params, callback) {
   options.priority = (options.priority || 0.5).toString();
   options.dest = options.dest || path.dirname(pages[0].dest);
   options.flattendirectoryindex = options.flattendirectoryindex || false;
+  options.outputfilename = options.outputfilename || 'sitemap.xml';
 
 
   // Only write if it actually changed.
@@ -98,7 +99,7 @@ module.exports  = function (params, callback) {
 
 
 
-  var sitemapDest = options.dest + '/sitemap.xml';
+  var sitemapDest = options.dest + "/" + options.outputfilename;
   write(sitemapDest, result);
 
   if (options.robot) {


### PR DESCRIPTION
This is an alternative to the other pull request for removing index.html from the sitemap. I also added an option for custom output filename for those with multiple sitemaps. I also fixed some documentation.
